### PR TITLE
Fixed `LaunchNavigator.navigate` never resolving the returned promise when AppleMaps/MapKit is used on iOS

### DIFF
--- a/ios/RNLaunchNavigator/LN_LaunchNavigator.m
+++ b/ios/RNLaunchNavigator/LN_LaunchNavigator.m
@@ -331,8 +331,9 @@ static NSDictionary* extras;
         }
     }
     
+    BOOL success;
     if([navigateParams[@"startType"] isEqual: LNLocTypeNone]){
-        [MKMapItem openMapsWithItems:@[dest_mapItem] launchOptions:launchOptions];
+        success = [MKMapItem openMapsWithItems:@[dest_mapItem] launchOptions:launchOptions];
     }else{
         if([self isNull:startAddress]){
             start_mapItem = [[MKMapItem alloc] initWithPlacemark:[[MKPlacemark alloc] initWithCoordinate:startCoord addressDictionary:nil]];
@@ -340,7 +341,12 @@ static NSDictionary* extras;
                 [start_mapItem setName:startName];
             }
         }
-        [MKMapItem openMapsWithItems:@[start_mapItem, dest_mapItem] launchOptions:launchOptions];
+        success = [MKMapItem openMapsWithItems:@[start_mapItem, dest_mapItem] launchOptions:launchOptions];
+    }
+    if(success){
+      self.navigateSuccess();
+    }else{
+      self.navigateFail([NSString stringWithFormat:@"Failed to open MapKit"]);
     }
 }
 


### PR DESCRIPTION
The promise returned from `LaunchNavigator.navigate` never resolved when using MapKit on iOS. This made it impossible/unreliable to test for errors. This PR fixes that issue by implementing a completion handler, much in the same way the schema launch operations are handled.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [X] Testing has been carried out for the changes have been added
- [X] Regression testing has been carried out for existing functionality
- [X] Docs have been added / updated *(not relevant)*

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing module versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this module, has it been updated to test the new functionality? -->

It has been verified that the promise returned from `LaunchNavigator.navigate` not successfully resolves using provider id `LaunchNavigator.APP.APPLE_MAPS` and launchMode `LaunchNavigator.LAUNCH_MODE.MAPKIT`.
